### PR TITLE
removed mdc-form-field because it is not registered

### DIFF
--- a/build/tasks/dev.js
+++ b/build/tasks/dev.js
@@ -1,4 +1,5 @@
 let gulp = require('gulp');
+let runSequence = require('run-sequence');
 let tools = require('aurelia-tools');
 let args = require('../args');
 
@@ -18,4 +19,14 @@ gulp.task('update-own-deps', function() {
 // and `gulp build` for each repo
 gulp.task('build-dev-env', function() {
     tools.buildDevEnv();
+});
+
+
+// calls the listed sequence of tasks in order
+gulp.task('dev-release', function(callback) {
+    return runSequence(
+        'build',
+        'lint',
+        callback
+    );
 });

--- a/dist/amd/config.js
+++ b/dist/amd/config.js
@@ -53,8 +53,7 @@ define(['exports'], function (exports) {
         'mdc-textfield': 'MDCTextfield',
         'mdc-simple-menu': 'MDCSimpleMenu',
         'mdc-select': 'MDCSelect',
-        'mdc-toolbar': 'MDCToolbar',
-        'mdc-form-field': 'MDCFormField'
+        'mdc-toolbar': 'MDCToolbar'
     };
 
     var MdcConfig = exports.MdcConfig = function () {

--- a/dist/commonjs/config.js
+++ b/dist/commonjs/config.js
@@ -28,8 +28,7 @@ var MDC_COMPONENTS = {
     'mdc-textfield': 'MDCTextfield',
     'mdc-simple-menu': 'MDCSimpleMenu',
     'mdc-select': 'MDCSelect',
-    'mdc-toolbar': 'MDCToolbar',
-    'mdc-form-field': 'MDCFormField'
+    'mdc-toolbar': 'MDCToolbar'
 };
 
 var MdcConfig = exports.MdcConfig = function () {

--- a/dist/es2015/config.js
+++ b/dist/es2015/config.js
@@ -16,8 +16,7 @@ let MDC_COMPONENTS = {
     'mdc-textfield': 'MDCTextfield',
     'mdc-simple-menu': 'MDCSimpleMenu',
     'mdc-select': 'MDCSelect',
-    'mdc-toolbar': 'MDCToolbar',
-    'mdc-form-field': 'MDCFormField'
+    'mdc-toolbar': 'MDCToolbar'
 };
 
 export let MdcConfig = class MdcConfig {

--- a/dist/system/config.js
+++ b/dist/system/config.js
@@ -61,8 +61,7 @@ System.register([], function (_export, _context) {
                 'mdc-textfield': 'MDCTextfield',
                 'mdc-simple-menu': 'MDCSimpleMenu',
                 'mdc-select': 'MDCSelect',
-                'mdc-toolbar': 'MDCToolbar',
-                'mdc-form-field': 'MDCFormField'
+                'mdc-toolbar': 'MDCToolbar'
             };
 
             _export('MdcConfig', MdcConfig = function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aurelia-mdc-plugin",
-    "version": "0.4.2",
+    "version": "0.4.4",
     "description": "Material Design Components plugin for Aurelia.",
     "keywords": [
         "aurelia",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "material design"
     ],
     "scripts": {
+        "dev-release": "gulp build",
         "prepush": "gulp prepare-release --bump=patch",
         "push": "git add --all && git commit -m \"$(date)\" && git push origin master && npm publish",
         "test": "gulp test"

--- a/src/config.js
+++ b/src/config.js
@@ -16,8 +16,7 @@ let MDC_COMPONENTS = {
     'mdc-textfield': 'MDCTextfield',
     'mdc-simple-menu': 'MDCSimpleMenu',
     'mdc-select': 'MDCSelect',
-    'mdc-toolbar': 'MDCToolbar',
-    'mdc-form-field': 'MDCFormField'
+    'mdc-toolbar': 'MDCToolbar'
 };
 
 export class MdcConfig {


### PR DESCRIPTION
I'm getting this error

`Unhandled rejection Error: (mdc-auto-init) Could not find constructor in registry for MDCFormField`

`MDCFormField` will never be registered by material-components-web. see: 
https://github.com/material-components/material-components-web/blob/master/packages/material-components-web/index.js#L36